### PR TITLE
Adding brands to a products via the REST API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+.idea


### PR DESCRIPTION
When adding a `brands` key containing an array of (existing) brand id's, these brands will be attached to the product. 

When an empty array is given, all brands will be detached.

```
products: {
    'id' : //...
    'brands' : [
        '1','2','3'
    ]
}
```

Also refactored some code because of this addition to make things more manageable, and added some comments (+ PSR-2 standard for this file. Sorry about that ;-)).

I needed this for a project, and I found out you just added API capabilities for getting, so I'm just adding on to your work. Please consider a merge. Thanks!