### PR TITLE
Make $result_brands unique prior to slicing via $limit.

### DIFF
--- a/classes/widgets/class-pwb-filter-by-brand.php
+++ b/classes/widgets/class-pwb-filter-by-brand.php
@@ -106,6 +106,8 @@ class PWB_Filter_By_Brand_Widget extends \WP_Widget {
 
 		if( is_product_category() ){
 
+			    $result_brands = array();
+
 				if( $the_query->have_posts() ) {
 					while ( $the_query->have_posts() ) {
 						$the_query->the_post();
@@ -116,7 +118,8 @@ class PWB_Filter_By_Brand_Widget extends \WP_Widget {
 				}
 				wp_reset_postdata();
 
-				$cate = get_queried_object();
+    			        $result_brands = array_unique($result_brands);
+	    		        $cate = get_queried_object();
 				$cateID = $cate->term_id;
 				$cate_url = get_term_link($cateID);
 
@@ -134,7 +137,6 @@ class PWB_Filter_By_Brand_Widget extends \WP_Widget {
 
       if( !empty( $result_brands ) ){
 
-        $result_brands         = array_unique($result_brands);
         $result_brands_ordered = array();
         foreach( $result_brands as $brand ){
           $brand = get_term($brand);


### PR DESCRIPTION
This fix ensures that the $result_brands array is made unique _before_ it has been passed into the array_slice() function. Currently the limit argument is misleading, as it slices the non-unique brands array, thus inadvertently removing valid brands, if many duplicates exist.